### PR TITLE
Semantic passes and Bug fixes for casting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with: 
           version: 0.12.0
       - run: zig test src/tacGenTests.zig &&  zig test src/semanticTests.zig && zig test src/codegenTests.zig  && zig test src/parserTests.zig && zig test src/staticStorageTests.zig
-      - run: cd cFiles && sh run.sh
+      - run: cd cFiles && sh test.sh
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test
 *.log
 TODO.md
 temp*
+ssa.md

--- a/cFiles/clean.sh
+++ b/cFiles/clean.sh
@@ -1,1 +1,2 @@
 rm -rf ./C/* ./S/*
+find . -type f -executable -delete

--- a/cFiles/run.sh
+++ b/cFiles/run.sh
@@ -1,4 +1,4 @@
-podman rm -vf $(podman ps -a -q)
-podman build -t zig-cc-testing .
+docker rm -vf $(docker ps -a -q)
+docker build -t zig-cc-testing .
 #podman run -it zig-cc-testing /bin/bash
-podman run -it zig-cc-testing /bin/bash test.sh
+docker run -it zig-cc-testing /bin/bash test.sh

--- a/cFiles/test.sh
+++ b/cFiles/test.sh
@@ -1,21 +1,11 @@
-# Run every c s file pair
-# check if the compiled executed out of them are equal
-
-# loop through the dir
-# have a c folder and an asm folder 
-# iterate through the c folder, get basename
-# find the .s file in the s folder,
-# compile both via gcc
-# execute
-# check if there is a difference in output
-
+#!/bin/bash
 
 C_DIR="./C"
 S_DIR="./S"
 
 for file in "$C_DIR"/*.c; do
     echo "$file"
-    base_name=${file#$C_DIR/}
+    base_name=${file#"$C_DIR/"}
     base_name=${base_name%.c}
     echo "$base_name"
     

--- a/src/Assembly.zig
+++ b/src/Assembly.zig
@@ -279,9 +279,9 @@ pub const BinaryOp = enum {
     Multiply,
     pub fn stringify(self: BinaryOp, allocator: std.mem.Allocator) ast.CodegenError![]u8 {
         return (try std.fmt.allocPrint(allocator, "{s}", .{switch (self) {
-            .Add => "addl",
-            .Subtract => "subl",
-            .Multiply => "imull",
+            .Add => "add",
+            .Subtract => "sub",
+            .Multiply => "imul",
         }}));
     }
 };
@@ -393,7 +393,7 @@ pub const Instruction = union(InstructionType) {
                 const lhsOperand = try @constCast(&binary.lhs).stringify(allocator);
                 const rhsOperand = try @constCast(&binary.rhs).stringify(allocator);
                 const instrString = try binary.op.stringify(allocator);
-                return (try std.fmt.allocPrint(allocator, "{s} {s},{s}", .{ instrString, rhsOperand, lhsOperand }));
+                return (try std.fmt.allocPrint(allocator, "{s}{c} {s},{s}", .{ instrString, binary.type.suffix(), rhsOperand, lhsOperand }));
             },
             .Cdq => {
                 return (try std.fmt.allocPrint(allocator, "cdq", .{}));

--- a/src/Assembly.zig
+++ b/src/Assembly.zig
@@ -146,6 +146,7 @@ pub const Reg = enum {
     R8,
     R9,
     EAX,
+    RAX,
     R11_64, // TODO: Rename this later
     R10_64,
     pub fn stringify(register: Reg, allocator: std.mem.Allocator) ast.CodegenError![]u8 {
@@ -188,6 +189,9 @@ pub const Reg = enum {
             },
             .EAX => {
                 return (try std.fmt.allocPrint(allocator, "%eax", .{}));
+            },
+            .RAX => {
+                return (try std.fmt.allocPrint(allocator, "%rax", .{}));
             },
         }
     }

--- a/src/Assembly.zig
+++ b/src/Assembly.zig
@@ -145,6 +145,12 @@ pub const Reg = enum {
     ECX,
     R8,
     R9,
+    RDI,
+    RSI,
+    RDX,
+    RCX,
+    R8_64,
+    R9_64,
     EAX,
     RAX,
     R11_64, // TODO: Rename this later
@@ -181,11 +187,29 @@ pub const Reg = enum {
             .ECX => {
                 return (try std.fmt.allocPrint(allocator, "%ecx", .{}));
             },
+            .RDI => {
+                return (try std.fmt.allocPrint(allocator, "%rdi", .{}));
+            },
+            .RSI => {
+                return (try std.fmt.allocPrint(allocator, "%rsi", .{}));
+            },
+            .RDX => {
+                return (try std.fmt.allocPrint(allocator, "%rdx", .{}));
+            },
+            .RCX => {
+                return (try std.fmt.allocPrint(allocator, "%rcx", .{}));
+            },
             .R8 => {
                 return (try std.fmt.allocPrint(allocator, "%r8d", .{}));
             },
             .R9 => {
                 return (try std.fmt.allocPrint(allocator, "%r9d", .{}));
+            },
+            .R8_64 => {
+                return (try std.fmt.allocPrint(allocator, "%r8", .{}));
+            },
+            .R9_64 => {
+                return (try std.fmt.allocPrint(allocator, "%r9", .{}));
             },
             .EAX => {
                 return (try std.fmt.allocPrint(allocator, "%eax", .{}));
@@ -426,7 +450,7 @@ pub const Instruction = union(InstructionType) {
             },
             .Movsx => |movsx| {
                 std.log.warn("Hey I am hit\n", .{});
-                return (try std.fmt.allocPrint(allocator, "movsx {s},{s}", .{ try Operand.stringify(@constCast(&movsx.src), allocator), try Operand.stringify(@constCast(&movsx.dest), allocator) }));
+                return (try std.fmt.allocPrint(allocator, "movslq {s},{s}", .{ try Operand.stringify(@constCast(&movsx.src), allocator), try Operand.stringify(@constCast(&movsx.dest), allocator) }));
             },
         }
     }
@@ -437,7 +461,10 @@ inline fn fixMultiply(inst: *Instruction, allocator: std.mem.Allocator, fixedIns
         const movLeftToR11 = try allocator.create(Instruction);
         movLeftToR11.* = Instruction{
             .Mov = MovInst{
-                .dest = Operand{ .Reg = Reg.R11 },
+                .dest = Operand{ .Reg = switch (inst.Binary.type) {
+                    .LongWord => .R11,
+                    .QuadWord => .R11_64,
+                } },
                 .src = inst.Binary.lhs,
                 .type = inst.Binary.type,
             },
@@ -445,10 +472,18 @@ inline fn fixMultiply(inst: *Instruction, allocator: std.mem.Allocator, fixedIns
         const movR11ToLeft = try allocator.create(Instruction);
         movR11ToLeft.* = Instruction{ .Mov = MovInst{
             .dest = inst.Binary.lhs,
-            .src = Operand{ .Reg = Reg.R11 },
+            .src = Operand{ .Reg = switch (inst.Binary.type) {
+                .QuadWord => .R11_64,
+                .LongWord => .R11,
+            } },
             .type = inst.Binary.type,
         } };
-        inst.Binary.lhs = Operand{ .Reg = Reg.R11 };
+        inst.Binary.lhs = Operand{
+            .Reg = switch (inst.Binary.type) {
+                .LongWord => .R11,
+                .QuadWord => .R11_64,
+            },
+        };
         try fixedInstructions.append(movLeftToR11);
         try fixedInstructions.append(inst);
         try fixedInstructions.append(movR11ToLeft);
@@ -465,7 +500,11 @@ pub fn fixupInstructions(instructions: *std.ArrayList(*Instruction), allocator: 
             .Mov => |mov| {
                 const isSrcMem = mov.src.isOfKind(.Data) or mov.src.isOfKind(.Stack);
                 const isDestMem = mov.dest.isOfKind(.Data) or mov.dest.isOfKind(.Stack);
-                if (isSrcMem and isDestMem) {
+                // in case of quad word mov instructions, a quadword immediate
+                // cannot be moved directly into memory, hence require an
+                // intermediate register move
+                const quadWordImmMov = (mov.type == .QuadWord) and mov.src.isOfKind(.Imm);
+                if ((isSrcMem and isDestMem) or quadWordImmMov) {
                     //_ = instructions.orderedRemove(i);
                     const movInstSrc = try allocator.create(Instruction);
                     const movInstDest = try allocator.create(Instruction);
@@ -534,7 +573,7 @@ pub fn fixupInstructions(instructions: *std.ArrayList(*Instruction), allocator: 
                 }
             },
             .Cmp => |cmp| {
-                const isOp1Mem = cmp.op1.isOfKind(.Data) or cmp.op1.isOfKind(.Stack);
+                const isOp1Mem = cmp.op1.isOfKind(.Data) or cmp.op1.isOfKind(.Stack) or cmp.op1.isOfKind(.Imm);
                 const isOp2Mem = cmp.op2.isOfKind(.Data) or cmp.op2.isOfKind(.Stack);
                 if (isOp1Mem and isOp2Mem) {
                     const movInst = try allocator.create(Instruction);

--- a/src/TAC.zig
+++ b/src/TAC.zig
@@ -424,7 +424,10 @@ pub const Instruction = union(InstructionType) {
                             .Idiv = right,
                         };
                         movDXToDest.* = assembly.Instruction{ .Mov = assembly.MovInst{
-                            .src = assembly.Operand{ .Reg = assembly.Reg.DX },
+                            .src = assembly.Operand{ .Reg = switch (storeDestType) {
+                                .LongWord => assembly.Reg.EDX,
+                                .QuadWord => assembly.Reg.RDX,
+                            } },
                             .dest = storeDest,
                             .type = storeDestType,
                         } };
@@ -546,7 +549,8 @@ pub const Instruction = union(InstructionType) {
                 try instructions.append(label);
             },
             .FunctionCall => |fnCall| {
-                const registers = [_]assembly.Reg{ assembly.Reg.EDI, assembly.Reg.ESI, assembly.Reg.EDX, assembly.Reg.ECX, assembly.Reg.R8, assembly.Reg.R9 };
+                const registers32 = [_]assembly.Reg{ assembly.Reg.EDI, assembly.Reg.ESI, assembly.Reg.EDX, assembly.Reg.ECX, assembly.Reg.R8, assembly.Reg.R9 };
+                const registers64 = [_]assembly.Reg{ assembly.Reg.RDI, assembly.Reg.RSI, assembly.Reg.RDX, assembly.Reg.RCX, assembly.Reg.R8_64, assembly.Reg.R9_64 };
                 if (fnCall.args.items.len < 6) {
                     for (fnCall.args.items, 0..) |arg, i| {
                         const movArgToReg = try allocator.create(assembly.Instruction);
@@ -555,7 +559,10 @@ pub const Instruction = union(InstructionType) {
                         movArgToReg.* = assembly.Instruction{
                             .Mov = assembly.MovInst{
                                 .src = assemblyArg,
-                                .dest = assembly.Operand{ .Reg = registers[i] },
+                                .dest = assembly.Operand{ .Reg = switch (assemblyArgType) {
+                                    .LongWord => registers32[i],
+                                    .QuadWord => registers64[i],
+                                } },
                                 .type = assemblyArgType,
                             },
                         };

--- a/src/TAC.zig
+++ b/src/TAC.zig
@@ -295,7 +295,12 @@ pub const Instruction = union(InstructionType) {
                 movInst.* = assembly.Instruction{ .Mov = assembly.MovInst{
                     .type = instType,
                     .src = val,
-                    .dest = assembly.Operand{ .Reg = assembly.Reg.AX },
+                    .dest = assembly.Operand{
+                        .Reg = switch (instType) {
+                            .LongWord => .EAX,
+                            .QuadWord => .RAX,
+                        },
+                    },
                 } };
                 const retInst = try allocator.create(assembly.Instruction);
                 retInst.* = assembly.Instruction{ .Ret = {} };
@@ -368,7 +373,12 @@ pub const Instruction = union(InstructionType) {
                         const movAXToDest = try allocator.create(assembly.Instruction);
                         movLeftToAX.* = assembly.Instruction{ .Mov = assembly.MovInst{
                             .src = left,
-                            .dest = assembly.Operand{ .Reg = assembly.Reg.AX },
+                            .dest = assembly.Operand{
+                                .Reg = switch (binary.left.getTypeFromSymTab(symbolTable).?) {
+                                    .LongWord => .EAX,
+                                    .QuadWord => .RAX,
+                                },
+                            },
                             .type = binary.left.getTypeFromSymTab(symbolTable).?,
                         } };
                         cdqInstr.* = assembly.Instruction{
@@ -378,7 +388,12 @@ pub const Instruction = union(InstructionType) {
                             .Idiv = right,
                         };
                         movAXToDest.* = assembly.Instruction{ .Mov = assembly.MovInst{
-                            .src = assembly.Operand{ .Reg = assembly.Reg.AX },
+                            .src = assembly.Operand{
+                                .Reg = switch (storeDestType) {
+                                    .LongWord => .EAX,
+                                    .QuadWord => .RAX,
+                                },
+                            },
                             .dest = storeDest,
                             .type = storeDestType,
                         } };
@@ -394,7 +409,12 @@ pub const Instruction = union(InstructionType) {
                         const movDXToDest = try allocator.create(assembly.Instruction);
                         movLeftToDX.* = assembly.Instruction{ .Mov = assembly.MovInst{
                             .src = left,
-                            .dest = assembly.Operand{ .Reg = assembly.Reg.AX },
+                            .dest = assembly.Operand{
+                                .Reg = switch (binary.left.getTypeFromSymTab(symbolTable).?) {
+                                    .LongWord => .EAX,
+                                    .QuadWord => .RAX,
+                                },
+                            },
                             .type = binary.left.getTypeFromSymTab(symbolTable).?,
                         } };
                         cdqInstr.* = assembly.Instruction{

--- a/src/codegenTests.zig
+++ b/src/codegenTests.zig
@@ -667,3 +667,97 @@ test "truncation" {
     try asmProgram.stringify(sFileWriter, allocator, tacRenderer.asmSymbolTable);
     try cFileWriter.writeAll(programStr);
 }
+
+test "big test for casting" {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    const allocator = arena.allocator();
+    defer arena.deinit();
+    const cFileWriter = (try std.fs.cwd().createFile("./cFiles/C/allCasting.c", .{})).writer();
+    const sFileWriter = (try std.fs.cwd().createFile("./cFiles/S/allCasting.s", .{})).writer();
+    const programStr =
+        \\
+        \\long a;
+        \\long b;
+        \\
+        \\int addition() {
+        \\    return (a + b == 4294967295L);
+        \\}
+        \\
+        \\int subtraction() {
+        \\    return (a - b == -4294967380L);
+        \\}
+        \\
+        \\int multiplication() {
+        \\    return (a * 4L == 17179869160L);
+        \\}
+        \\
+        \\int division() {
+        \\    b = a / 128L;
+        \\    return (b == 33554431L);
+        \\}
+        \\
+        \\int remaind() {
+        \\    b = -a % 4294967290L;
+        \\    return (b == -5L);
+        \\}
+        \\
+        \\int complement() {
+        \\    return (~a == -9223372036854775807L);
+        \\}
+        \\
+        \\int main() {
+        \\    a = 4294967290L;
+        \\    b = 5L;
+        \\    if (addition() != 0) {
+        \\        return 1;
+        \\    }
+        \\
+        \\    a = -4294967290L;
+        \\    b = 90L;
+        \\    if (subtraction() != 0) {
+        \\        return 2;
+        \\    }
+        \\
+        \\    a = 4294967290L;
+        \\    if (multiplication() == 0) {
+        \\        return 3;
+        \\    }
+        \\
+        \\    a = 4294967290L;
+        \\    if (division() == 0) {
+        \\        return 4;
+        \\    }
+        \\
+        \\    a = 8589934585L;
+        \\    if (remaind() == 0) {
+        \\        return 5;
+        \\    }
+        \\
+        \\    a = 9223372036854775806L;
+        \\    if (complement() == 0) {
+        \\        return 6;
+        \\    }
+        \\
+        \\    return 0;
+        \\}
+    ;
+
+    const l = try lexer.Lexer.init(allocator, @as([]u8, @constCast(programStr)));
+    var p = try parser.Parser.init(allocator, l);
+    const program = try p.parseProgram();
+    const varResolver = try ast.VarResolver.init(allocator);
+    try varResolver.resolve(program);
+    const typechecker = try semantic.Typechecker.init(allocator);
+    const hasTypeErr = try typechecker.check(program);
+    if (hasTypeErr) |typeError| {
+        std.log.warn("\x1b[33mError\x1b[0m: {s}\n", .{typeError});
+        std.debug.assert(false);
+    }
+    try ast.loopLabelPass(program, allocator);
+    const tacRenderer = try ast.TACRenderer.init(allocator, typechecker.symbolTable);
+    const tacProgram = try tacRenderer.render(program);
+    const asmRenderer = try tac.AsmRenderer.init(allocator, tacRenderer.asmSymbolTable);
+    const asmProgram = try asmRenderer.render(tacProgram);
+    try asmProgram.stringify(sFileWriter, allocator, tacRenderer.asmSymbolTable);
+    try cFileWriter.writeAll(programStr);
+}

--- a/src/codegenTests.zig
+++ b/src/codegenTests.zig
@@ -634,3 +634,36 @@ test "casting with div" {
     try asmProgram.stringify(sFileWriter, allocator, tacRenderer.asmSymbolTable);
     try cFileWriter.writeAll(programStr);
 }
+
+test "truncation" {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    const allocator = arena.allocator();
+    defer arena.deinit();
+    const cFileWriter = (try std.fs.cwd().createFile("./cFiles/C/truncation.c", .{})).writer();
+    const sFileWriter = (try std.fs.cwd().createFile("./cFiles/S/truncation.s", .{})).writer();
+    const programStr =
+        \\int main() {
+        \\    long l = 2147483653;
+        \\    int i = l;
+        \\    return i;
+        \\}
+    ;
+    const l = try lexer.Lexer.init(allocator, @as([]u8, @constCast(programStr)));
+    var p = try parser.Parser.init(allocator, l);
+    const program = try p.parseProgram();
+    const varResolver = try ast.VarResolver.init(allocator);
+    try varResolver.resolve(program);
+    const typechecker = try semantic.Typechecker.init(allocator);
+    const hasTypeErr = try typechecker.check(program);
+    if (hasTypeErr) |typeError| {
+        std.log.warn("\x1b[33mError\x1b[0m: {s}\n", .{typeError});
+        std.debug.assert(false);
+    }
+    try ast.loopLabelPass(program, allocator);
+    const tacRenderer = try ast.TACRenderer.init(allocator, typechecker.symbolTable);
+    const tacProgram = try tacRenderer.render(program);
+    const asmRenderer = try tac.AsmRenderer.init(allocator, tacRenderer.asmSymbolTable);
+    const asmProgram = try asmRenderer.render(tacProgram);
+    try asmProgram.stringify(sFileWriter, allocator, tacRenderer.asmSymbolTable);
+    try cFileWriter.writeAll(programStr);
+}

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -481,7 +481,9 @@ pub const Parser = struct {
         // Identifier
         const currToken = try self.l.nextToken(self.allocator);
         const identifier = try self.allocator.create(AST.Expression);
-        identifier.* = AST.Expression{ .Identifier = .{ .name = self.l.buffer[currToken.start .. currToken.end + 1] } };
+        identifier.* = AST.Expression{ .Identifier = .{
+            .name = self.l.buffer[currToken.start .. currToken.end + 1],
+        } };
         return identifier;
     }
 

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -65,6 +65,7 @@ pub const TypeError = error{
     ExternVarDeclared,
     FnRedeclaredAsVar,
     ConflictingDeclarations,
+    FnPrevDeclArgMismatch,
 };
 
 const TypeCheckerError = error{OutOfMemory} || TypeError;
@@ -205,6 +206,20 @@ pub fn typecheckExternalDecl(self: *Typechecker, externalDecl: *AST.ExternalDecl
                             .{functionDecl.name},
                         ),
                     );
+                }
+
+                for (0..functionDecl.args.items.len) |i| {
+                    if (functionDecl.args.items[i].NonVoidArg.type != sym.typeInfo.Function.args.items[i]) {
+                        return TypeErrorStruct.typeError(
+                            self.allocator,
+                            TypeError.FnPrevDeclArgMismatch,
+                            try std.fmt.allocPrint(self.allocator, "Argument mismatch in function redeclaration: function name = {s}, function arg mismatch between {any} and {any}\n", .{
+                                functionDecl.name,
+                                functionDecl.args.items[i].NonVoidArg.type,
+                                sym.typeInfo.Function.args.items[i],
+                            }),
+                        );
+                    }
                 }
 
                 if (functionDecl.args.items.len != sym.typeInfo.Function.args.items.len) {

--- a/src/semanticTests.zig
+++ b/src/semanticTests.zig
@@ -576,29 +576,29 @@ test "extern conflict int and longs" {
     _ = try std.testing.expect(hasErr);
 }
 
-//test "function definition with different types" {
-//    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-//    const allocator = arena.allocator();
-//    defer arena.deinit();
-//    const programStr =
-//        \\ long add(int a, int b);
-//        \\ long add(long a, long b);
-//        \\ int main(){
-//        \\     extern int k;
-//        \\     return 0;
-//        \\ }
-//    ;
-//    const l = try lexer.Lexer.init(allocator, @as([]u8, @constCast(programStr)));
-//    var p = try parser.Parser.init(allocator, l);
-//    const program = try p.parseProgram();
-//    const varResolver = try ast.VarResolver.init(allocator);
-//    try varResolver.resolve(program);
-//    const typechecker = try semantic.Typechecker.init(allocator);
-//    const hasTypeErr = try typechecker.check(program);
-//    var hasErr = false;
-//    if (hasTypeErr) |typeErr| {
-//        std.log.warn("Type error: {s}\n", .{typeErr});
-//        hasErr = true;
-//    }
-//    _ = try std.testing.expect(hasErr);
-//}
+test "function definition with different types" {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    const allocator = arena.allocator();
+    defer arena.deinit();
+    const programStr =
+        \\ long add(int a, int b);
+        \\ long add(long a, long b);
+        \\ int main(){
+        \\     extern int k;
+        \\     return 0;
+        \\ }
+    ;
+    const l = try lexer.Lexer.init(allocator, @as([]u8, @constCast(programStr)));
+    var p = try parser.Parser.init(allocator, l);
+    const program = try p.parseProgram();
+    const varResolver = try ast.VarResolver.init(allocator);
+    try varResolver.resolve(program);
+    const typechecker = try semantic.Typechecker.init(allocator);
+    const hasTypeErr = try typechecker.check(program);
+    var hasErr = false;
+    if (hasTypeErr) |typeErr| {
+        std.log.warn("Type error: {s}\n", .{typeErr});
+        hasErr = true;
+    }
+    _ = try std.testing.expect(hasErr);
+}


### PR DESCRIPTION
- 🛠️ Fix: truncate not being hit, added test case previously failing and now succeeding
- 🛠 Fix: moving to the eax register was not being handled for different sizes, tests now succeeding
- ✨ handling casting for function arguments in function calls
- ✨ Feat: semantic pass to find type mismatch in function redeclarations
- 🛠 Fix: big testcase passing for casting
